### PR TITLE
Use `gcloud app` instead of `gcloud preview app`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ the final code product of the tutorial and includes language detection.
 
 ## Deploy
 
-$ gcloud preview app deploy --project=${YOUR_PROJECT_NAME}
+$ gcloud app deploy --project=${YOUR_PROJECT_NAME}
 
 [1]: https://console.developers.google.com/project


### PR DESCRIPTION
We should use `gcloud app` instead of `gcloud preview app` which will go away soon.
